### PR TITLE
background rgb param needs to be a tuple

### DIFF
--- a/PhotoCollage.py
+++ b/PhotoCollage.py
@@ -513,7 +513,7 @@ def makeCollage(img_list,
 def make_arg_parser():
     def rgb(s):
         try:
-            rgb = (0 if v < 0 else 255 if v > 255 else v for v in map(int, s.split(',')))
+            rgb = tuple(0 if v < 0 else 255 if v > 255 else v for v in map(int, s.split(',')))
             return rgb
         except:
             raise argparse.ArgumentTypeError('Background must be (r,g,b) --> "(0,0,0)" to "(255,255,255)"')


### PR DESCRIPTION
In CLI, command
`python3 PhotoCollage.py -f "pic folder" -o "result.png" -b 34,194,34`
would result in error
`TypeError: unsupported operand type(s) for +=: 'generator' and 'tuple'" `

Making the background parameter a tuple seemed to fix it and the above command correctly created a collage with a green background.

(Running on windows 10 with WSL)

## Summary by Sourcery

Bug Fixes:
- Fix issue where providing background RGB value as comma separated string in the command line resulted in a TypeError.